### PR TITLE
Making Python API client complaint to pyhon 2/3

### DIFF
--- a/client/python/musixmatch.py
+++ b/client/python/musixmatch.py
@@ -14,8 +14,8 @@ from swagger_client.rest import ApiException
 from pprint import pprint
 
 if len(sys.argv) <= 1:
-    print "\nUsage: python musixmatch.py YOUR_API_KEY";
-    exit();
+    print("\nUsage: python musixmatch.py YOUR_API_KEY")
+    exit()
 
 # str | Account api key, to be used in every api call
 swagger_client.configuration.api_key['apikey'] = sys.argv[1]
@@ -30,4 +30,4 @@ try:
     api_response = api_instance.album_get_get(album_id, format=format)
     pprint(api_response)
 except ApiException as e:
-    print "Exception when calling DefaultApi->album_get_get: %s\n" % e
+    print("Exception when calling DefaultApi->album_get_get: %s\n" % e)


### PR DESCRIPTION
Deleting the semicolon at lines 17 and 18, cause python doesn't need that;
Update the print statement at lines 17 and 33 to make "Musixmatch Python API client" complaint to both python 2 and 3